### PR TITLE
Handle images with transparency

### DIFF
--- a/lib/borealis/cluster.rb
+++ b/lib/borealis/cluster.rb
@@ -8,6 +8,10 @@ class Borealis
     end
 
     def recenter!
+      if colors.empty?
+        return 255
+      end
+
       red_sum = green_sum = blue_sum = 0
 
       colors.each do |color|

--- a/lib/borealis/image_converter.rb
+++ b/lib/borealis/image_converter.rb
@@ -23,11 +23,12 @@ class Borealis
     def colors_for(data)
       lines = data.split("\n").drop(1)
       lines.map do |line|
-        line = line.scan(/\(([\d+\s+,]+)\)/).flatten
-        rgb_values = line.first.split(',').map { |value| value.to_i }
-
-        Color.new(*rgb_values)
-      end
+        rgb_values = line.scan(/\(([\d+\s*,]+)\)/).flatten.first
+        if rgb_values
+          rgb_values = rgb_values.split(',').map { |value| value.to_i }
+          Color.new(*rgb_values.first(3))
+        end
+      end.compact
     end
   end
 end


### PR DESCRIPTION
- Prevent Color from receiving too many arguments
  
  I noticed this passing 4 values for a GIF with transparency. ImageMagick
  outputs in the following format in that case:
  
  ```
  25,2: (228,229,237,  0)  #E4E5ED00  srgba(228,229,237,0)
  ```
  
  Which causes an extra argument to be passed.
- Fix rows with no colors (transparent rows) causing issues with
  clustering.
